### PR TITLE
added BoundModelForm

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -1,1 +1,8 @@
 from django import forms
+
+
+class BoundModelForm(forms.ModelForm):
+    def save(self, commit=True, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self.instance, key, value)
+        super(forms.ModelForm, self).save(commit)


### PR DESCRIPTION
Klasa do łatwego tworzenia obiektów zależnych od istnienia innych (np. dodanie kolejki jest zależne od kontekstu tournamentu do którego jest dodawana -> <int:tournamentid> -> form.save(tournament=Tournament.objects.get(id=tournamentid)). W czystym django metoda save w ModelForm nie pozwala na przekazanie dodatkowych wartości pól do instancji obiektu przez co trzeba bezsensownie sczytywać dane z każdego pola w form ręcznie