### PR TITLE
DARK49_default_bot

### DIFF
--- a/dark/forms/tournament/team/bot/add.py
+++ b/dark/forms/tournament/team/bot/add.py
@@ -6,4 +6,4 @@ from dark.models.tournament.team import TeamBot
 class AddTeamBotForm(ModelForm):
     class Meta:
         model = TeamBot
-        fields = ['bot_url']
+        fields = ['bot_code']

--- a/dark/forms/tournament/team/bot/modify.py
+++ b/dark/forms/tournament/team/bot/modify.py
@@ -6,4 +6,4 @@ from dark.models.tournament.team import TeamBot
 class ModifyTeamBotForm(ModelForm):
     class Meta:
         model = TeamBot
-        fields = ['bot_url']
+        fields = ['bot_code']

--- a/dark/models/tournament/team/bot/bot.py
+++ b/dark/models/tournament/team/bot/bot.py
@@ -1,38 +1,86 @@
+import builtins
+import os
+import uuid
+
 from django.db import models
+from django.dispatch import receiver
 
 from .. import Team
 from dark.models.tournament import TournamentRound
 
 
+bot_code_base_store_directory = "dark/data"
+
+
+def bot_code_upload_path(instance, filename):
+    return f'{bot_code_base_store_directory}/bots/' \
+           f'{instance.team.tournament.name}{{{instance.team.tournament.id}}}/' \
+           f'{str(uuid.uuid4())}.py'
+
+
 class TeamBot(models.Model):
+
+    max_length = 65535
+
     team = models.ForeignKey(Team, on_delete=models.CASCADE)
     tround = models.ForeignKey(TournamentRound, on_delete=models.CASCADE)
-    bot_url = models.URLField(default=None, blank=True, null=True)
-
-    download_directory = "DARK/bots"
+    bot_code = models.FileField(default=None, max_length=max_length, upload_to=bot_code_upload_path)
 
     def __str__(self):
-        return self.bot_url
+        return self.bot_code.name
 
     class Meta:
         ordering = ['team', 'tround']
         unique_together = ("team", "tround")
 
 
-'''
-    def extract_name_from_repo_path(self, repo_path : str):
-        full_path = git.Repo(self.bot_url).remotes.origin.url
-        repo_name = full_path.split('.git')[0].split('/')[-1]
-        return repo_name
+@receiver(models.signals.post_delete, sender=TeamBot)
+def auto_delete_file_on_delete(sender, instance, **kwargs):
+    if instance.bot_code:
+        if os.path.isfile(instance.bot_code.path):
+            os.remove(instance.bot_code.path)
 
-    def sync(self):
-        git.Git(f'{Bot.download_directory}/'
-                f'{self.team.name}/'
-                f'{self.tround.name}/'
-                f'{self.extract_name_from_repo_path(self.bot_url)}')\
-            .clone(self.bot_url)
 
-    def run_on(self, tround: Round):
-        self.sync()
-        pass
-'''
+@receiver(models.signals.pre_save, sender=TeamBot)
+def auto_delete_file_on_change(sender, instance, **kwargs):
+    if not instance.id:
+        return False
+
+    try:
+        old_file = TeamBot.objects.get(id=instance.id).bot_code
+    except TeamBot.DoesNotExist:
+        return False
+
+    new_file = instance.bot_code
+    if not old_file == new_file:
+        if os.path.isfile(old_file.path):
+            os.remove(old_file.path)
+
+
+def secure_importer(name, **kwargs):
+    # need some import wrapper that allows only basic python
+    # functionality + gupb modules
+    module = builtins.__import__(name, **kwargs)
+    return module
+
+
+@receiver(models.signals.post_save, sender=TeamBot)
+def run_sandbox_check_correct_code(sender, instance, **kwargs):
+    file = TeamBot.objects.get(id=instance.id).bot_code
+
+    with open(file.path, 'r') as code:
+        file_content = code.read()
+        obj = compile("print('hello')", '', 'exec')
+        globs = {
+            '__builtins__': {
+                '__import__': secure_importer,
+            }
+        }
+        # TODO: sandboxing should be done here and if program failed to execute (or just parse)
+        # then throw some error and which would indicate that invalid program has been supplied
+        # TODO: bot must be executed in context (i.e importable modules) of platform
+        # and should be allowed to import basic (safe) builtin python modules
+        # maybe find some python sandboxing tool
+        # exec(obj, globs)
+
+

--- a/dark/templates/dark/tournament/team/bot/add.html
+++ b/dark/templates/dark/tournament/team/bot/add.html
@@ -10,7 +10,7 @@
 
 {% block content %}
     <div class="container pb-5">
-        <form method="post">
+        <form enctype="multipart/form-data" method="post">
             {% csrf_token %}
             {% for field in form %}
                 <div class="form-row justify-content-center">

--- a/dark/templates/dark/tournament/team/bot/all.html
+++ b/dark/templates/dark/tournament/team/bot/all.html
@@ -27,7 +27,7 @@
                 <td><a href="{% url 'tournament:tround:info' team.tournament.id tround.id %}">{{ tround.name }}</a></td>
                 <td>
                     {% if bot is not None %}
-                        <a href="{{ bot.bot_url }}">{{ bot.bot_url }}</a>
+                        {{ bot|stringformat:"s" }}
                         <button type="button" class="btn btn-primary btn-lg float-begin" onclick="location.href ='{% url 'tournament:team:bot:modify' team.tournament.id team.id bot.id %}'">
                             Modify
                         </button>

--- a/dark/templates/dark/tournament/team/bot/modify.html
+++ b/dark/templates/dark/tournament/team/bot/modify.html
@@ -14,7 +14,7 @@
             <div class="col-5"><b>Bot:</b> {{ bot.bot_url }}</div>
         </div>
         <div class="row mx-sm-5 mb-4 border border-secondary"></div>
-        <form method="post">
+        <form enctype="multipart/form-data"  method="post">
             {% csrf_token %}
             {% for field in form %}
                 <div class="form-row justify-content-center">

--- a/dark/views/tournament/team/bot/add.py
+++ b/dark/views/tournament/team/bot/add.py
@@ -1,20 +1,31 @@
-from django.views.generic import CreateView
+from django.shortcuts import render, redirect
+from django.views.generic import CreateView, View
 from django.urls import reverse
 
-from dark.models.tournament.team import TeamBot
+from dark.models.tournament import Tournament, TournamentRound
+from dark.models.tournament.team import TeamBot, Team
 from dark.forms.tournament.team import AddTeamBotForm
 from dark.common.views import ForeignKeysMixin
 
-
-class AddTeamBotView(ForeignKeysMixin, CreateView):
-    model = TeamBot
-    template_name = 'dark/tournament/team/bot/add.html'
+class AddTeamBotView(View):
     form_class = AddTeamBotForm
-    url_kwargs = ['team', 'tround']
-    url_kwarg_fields = ['team', 'tround']
+    template_name = 'dark/tournament/team/bot/add.html'
 
-    def get_success_url(self):
-        return reverse('tournament:team:bot:all', kwargs={
-            'tournament': self.object.team.tournament.id,
-            'team': self.object.team.id
-        })
+    def get(self, request, *args, **kwargs):
+        form = self.form_class()
+        return render(request, self.template_name, {'form': form})
+
+    def post(self, request, tournament, team, tround,  *args, **kwargs):
+        form = self.form_class(request.POST, request.FILES)
+        form.instance.team = Team.objects.get(id=team)
+        form.instance.tround = TournamentRound.objects.get(id=tround)
+        if form.is_valid():
+            obj = form.save()
+            return redirect(reverse('tournament:team:bot:all', kwargs={
+                'tournament': obj.team.tournament.id,
+                'team': obj.team.id
+            }))
+        else:
+            return render(request, self.template_name, {'form': form})
+
+

--- a/example/bot/random.py
+++ b/example/bot/random.py
@@ -1,0 +1,55 @@
+import random
+
+from gupb.model import arenas
+from gupb.model import characters
+
+POSSIBLE_ACTIONS = [
+    characters.Action.TURN_LEFT,
+    characters.Action.TURN_RIGHT,
+    characters.Action.STEP_FORWARD,
+    characters.Action.ATTACK,
+]
+
+TABARD_ASSIGNMENT = {
+    "Alice": characters.Tabard.BLUE,
+    "Bob": characters.Tabard.YELLOW,
+    "Cecilia": characters.Tabard.RED,
+    "Darius": characters.Tabard.GREY,
+}
+
+
+# noinspection PyUnusedLocal
+# noinspection PyMethodMayBeStatic
+class RandomController:
+    def __init__(self, first_name: str):
+        self.first_name: str = first_name
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, RandomController):
+            return self.first_name == other.first_name
+        return False
+
+    def __hash__(self) -> int:
+        return hash(self.first_name)
+
+    def reset(self, arena_description: arenas.ArenaDescription) -> None:
+        pass
+
+    def decide(self, knowledge: characters.ChampionKnowledge) -> characters.Action:
+        return random.choice(POSSIBLE_ACTIONS)
+
+    @property
+    def name(self) -> str:
+        return f'RandomController{self.first_name}'
+
+    @property
+    def preferred_tabard(self) -> characters.Tabard:
+        return TABARD_ASSIGNMENT[self.first_name] if self.first_name in TABARD_ASSIGNMENT else characters.Tabard.WHITE
+
+
+POTENTIAL_CONTROLLERS = [
+    RandomController("Alice"),
+    RandomController("Bob"),
+    RandomController("Cecilia"),
+    RandomController("Darius"),
+]


### PR DESCRIPTION
Zmieniłem sposób przechowywania bota (po prostu w jakimś pliku źródłowym - update modelu) zabawa z tym gitem dla jednego bota jest overkillem (pozatym wymaga złożonego systemu do wybierania konkretnego pliku itd. pozatym nie ustaliliśmy jakiegoś konkretnego sposobu w jaki mają być te boty przedstawione na repozytoriach)

Trzeba znaleźć jakieś narzędze sandboxujące do pythona bo teoretycznie da się ręcznie coś poustawiać w parametrach exec ale jest to niewiarygodnie niewygodne (a przydałoby sie ograniczyć pamięć/zakaz otwierania plikó itd.). Pozatym dobrze by było nie zasyfiać venva w którym pracuje nasz serwer jakimiś losowymi modułami (np. gdy odpalamy platforme a ona ma jakieś dependencje)

Dodałem random bota do dark/examples/bot/random.py żeby łatwo można było dodawać już go sobie potem do bazy

Na chwilę obecną nie da się ich odpalić (brak jakichkolwiek platform - pozatym ten sandboxing tool)
