### PR TITLE
DARK109_messages_display

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,5 +1,5 @@
 from split_settings.tools import optional, include
-
+from django.contrib.messages import constants as messages
 
 include(
     'options.py',
@@ -13,3 +13,11 @@ include(
 if 'HEROKU' in os.environ:
     import django_heroku
     django_heroku.settings(locals())
+
+MESSAGE_TAGS = {
+    messages.DEBUG: 'alert-info',
+    messages.INFO: 'alert-info',
+    messages.SUCCESS: 'alert-success',
+    messages.WARNING: 'alert-warning',
+    messages.ERROR: 'alert-danger',
+}

--- a/dark/templates/dark/base.html
+++ b/dark/templates/dark/base.html
@@ -49,7 +49,7 @@
 
             {#        temporaty adding platform button  #}
             <ul class="nav navbar-nav ms-auto w-100 justify-content-end"> {# Log/Register #}
-            {#        temporaty adding platform button  !!#}
+                {#        temporaty adding platform button  !!#}
                 <li class="nav-item active">
                     <a class="nav-link text-secondary " href="{% url 'platform:add' %}">Add platform</a>
                 </li>
@@ -68,10 +68,12 @@
                            role="button" data-bs-toggle="dropdown" aria-expanded="false"> Profile </a>
                         <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarScrollingDropdown">
                             <li class="nav-item active">
-                                <a class="dropdown-item text-dark" href="{% url 'teams:user all' user.username %}">Your Teams</a>
+                                <a class="dropdown-item text-dark" href="{% url 'teams:user all' user.username %}">Your
+                                    Teams</a>
                             </li>
                             <li class="nav-item active">
-                                <a class="dropdown-item text-dark" href="{% url 'tournament:user all' user.username %}">Your Tournaments</a>
+                                <a class="dropdown-item text-dark" href="{% url 'tournament:user all' user.username %}">Your
+                                    Tournaments</a>
                             </li>
                             <li>
                                 <hr class="dropdown-divider">
@@ -100,8 +102,18 @@
     </div>
 </div>
 
+{% if messages %}
+    <div class="alert alert-danger text-center" role="alert">
+        {% for message in messages %}
+            {{ message }} <br/>
+        {% endfor %}
+{#        <button type="button" class="btn btn-sm btn-outline-danger" data-bs-dismiss="alert" aria-label="Close">OK</button>#}
+    </div>
+{% endif %}
+
 <div class="container bg-white justify-content-center rounded mt-5 px-md-4 py-4 text-center text-dark"
      style="min-height: 75vh">
+
     {% block content %}
     {% endblock %}
 </div>

--- a/dark/templates/dark/base.html
+++ b/dark/templates/dark/base.html
@@ -6,6 +6,19 @@
     <link rel="stylesheet" type="text/css" href="{% static 'styleDark.css' %}">
     <meta charset="UTF-8">
 
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+            integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+            crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+            integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+            crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+            integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+            crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf"
+            crossorigin="anonymous"></script>
+
     {% block custom_style %} {# custom pages style #}
     {% endblock %}
 
@@ -27,6 +40,7 @@
         html, body {
             height: 100%;
         }
+
     </style>
     <title>DARK: tournament manager and organizer</title>
 </head>
@@ -103,12 +117,15 @@
 </div>
 
 {% if messages %}
-    <div class="alert alert-danger text-center" role="alert">
-        {% for message in messages %}
-            {{ message }} <br/>
-        {% endfor %}
-{#        <button type="button" class="btn btn-sm btn-outline-danger" data-bs-dismiss="alert" aria-label="Close">OK</button>#}
-    </div>
+    {% for message in messages %}
+        <div class="alert {% if message.tags %} {{ message.tags }} {% else %} alert-info alert-dismissible {% endif %} text-center mb-0"
+             role="alert">
+            <button type="button" class="close" data-dismiss="alert">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            {{ message }}
+        </div>
+    {% endfor %}
 {% endif %}
 
 <div class="container bg-white justify-content-center rounded mt-5 px-md-4 py-4 text-center text-dark"
@@ -117,11 +134,5 @@
     {% block content %}
     {% endblock %}
 </div>
-
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf"
-        crossorigin="anonymous"></script>
-
 </body>
 </html>

--- a/dark/templates/dark/tournament/all.html
+++ b/dark/templates/dark/tournament/all.html
@@ -8,6 +8,7 @@
 {% endblock %}
 
 
+
 {% block content %}
 
     <div class="text-center">


### PR DESCRIPTION
Dodane wyświetlanie wiadomości:
- wyświetlane są na górze strony jako alerty (dodane do base.html)
- można je zamknąć (dodałam importy js'owe do base.html - nie wiem czemu wcześniej ich nie było)
- kolorowanie alertu jest zależne od typu wiadomości (konfiguracja tego w settings.py)

Aktualnie jest tylko kilka miejsc w kodzie które powodują wyświetlenie wiadomości, więc do testów polecam stworzyć sobie prywatny turniej i spróbować się do niego dostać z linku jako niezalogowany użytkownik.

Screen na którym widać każdy z typów:
![image](https://user-images.githubusercontent.com/50996654/117301356-de139300-ae7a-11eb-9104-51c27eb58b60.png)
