### PR TITLE
DARK131_round_back_button_fix

### DIFF
--- a/dark/templates/dark/tournament/tround/info.html
+++ b/dark/templates/dark/tournament/tround/info.html
@@ -9,12 +9,8 @@
 
 {% block back %}
     <a type="button" class="float-left btn btn-secondary btn-sm mt-2 py-1 px-2"
-            {% if request.META.HTTP_REFERER %} href="{{ request.META.HTTP_REFERER }}">
-                Back to Details
-            {% else %}  href='{% url 'tournament:info' tround.tournament.id %}'>
-                {# this is called when user enters the site directly from link #}
-                Back to Tournament Details
-            {% endif %}
+       href='{% url 'tournament:info' tround.tournament.id %}'>
+        Back to Tournament Details
     </a>
 {% endblock %}
 


### PR DESCRIPTION
Cofanie do poprzedniej strony się wywalało w niektórych scenariuszach, więc ostatecznie przycisk będzie zawsze cofać do turnieju